### PR TITLE
Clean up NLP

### DIFF
--- a/server/backend/page_processor.py
+++ b/server/backend/page_processor.py
@@ -46,6 +46,9 @@ class PageProcessor:
             censoring_requirements, censoring_statements, censoring_topics
         )
         NLProcessor.ready()
+        # something in gensim/wmdistance is lazily initialized so we
+        # call similarity to prevent extra waiting time on first censoring
+        NLProcessor.similarity(' '.join(censoring_requirements))
         PageProcessor.__text_matcher = TextMatcher()
 
     def __init__(self, request):

--- a/server/backend/page_processor.py
+++ b/server/backend/page_processor.py
@@ -41,9 +41,9 @@ class PageProcessor:
     censoring_threshold = 10
 
     @staticmethod
-    def setup_censoring(censoring_requirements, censoring_statements, censoring_topics):
+    def setup_censoring(censoring_requirements, censoring_topic_comparison):
         NLProcessor.set_similarity_data(
-            censoring_requirements, censoring_statements, censoring_topics
+            censoring_requirements, censoring_topic_comparison
         )
         NLProcessor.ready()
         # something in gensim/wmdistance is lazily initialized so we

--- a/server/database/mock_database.py
+++ b/server/database/mock_database.py
@@ -9,20 +9,23 @@ class DatabaseNegative:
             with open(DATABASE_NEGATIVE_PATH, "r") as mock_db:
                 return yaml.safe_load(mock_db.read())
         except:
-            return dict()
+            return {
+                'articles': dict(),
+                'sources': list()
+            }
 
     @staticmethod
     def insert(topic, summary, source):
         data = DatabaseNegative.__get_data()
-        new = { 'summary': summary, 'source': source }
-        if topic in data: data[topic].append(new)
-        else: data[topic] = [new]
+        if topic in data['articles']: data['articles'][topic].append(summary)
+        else: data['articles'][topic] = [summary]
+        data['sources'].append(source)
         with open(DATABASE_NEGATIVE_PATH, "w") as mock_db:
             yaml.dump(data, mock_db, default_flow_style=False)
 
     @staticmethod
     def get_summaries_by_topics():
-        return DatabaseNegative.__get_data()
+        return DatabaseNegative.__get_data()['articles']
 
 class DatabasePositive:
     @staticmethod

--- a/server/database/mock_database.py
+++ b/server/database/mock_database.py
@@ -27,6 +27,10 @@ class DatabaseNegative:
     def get_summaries_by_topics():
         return DatabaseNegative.__get_data()['articles']
 
+    @staticmethod
+    def get_sources():
+        return DatabaseNegative.__get_data()['sources']
+
 class DatabasePositive:
     @staticmethod
     def __get_data():

--- a/server/database/mock_database.py
+++ b/server/database/mock_database.py
@@ -9,22 +9,20 @@ class DatabaseNegative:
             with open(DATABASE_NEGATIVE_PATH, "r") as mock_db:
                 return yaml.safe_load(mock_db.read())
         except:
-            return list()
+            return dict()
 
     @staticmethod
-    def insert(vals):
+    def insert(topic, summary, source):
         data = DatabaseNegative.__get_data()
-        data.append(dict(zip(["source", "text", "topic"], vals)))
+        new = { 'summary': summary, 'source': source }
+        if topic in data: data[topic].append(new)
+        else: data[topic] = [new]
         with open(DATABASE_NEGATIVE_PATH, "w") as mock_db:
             yaml.dump(data, mock_db, default_flow_style=False)
 
     @staticmethod
-    def get_summaries():
-        return [(row["text"], row["topic"]) for row in DatabaseNegative.__get_data()]
-
-    @staticmethod
-    def get_topics():
-        return list(set([row["topic"] for row in DatabaseNegative.__get_data()]))
+    def get_summaries_by_topics():
+        return DatabaseNegative.__get_data()
 
 class DatabasePositive:
     @staticmethod

--- a/server/helpers/cleanup.py
+++ b/server/helpers/cleanup.py
@@ -4,5 +4,5 @@ from definitions import TEMP_DIR
 
 def clear_temp_files():
     shutil.rmtree(TEMP_DIR)
-    os.mkdirs(TEMP_DIR)
+    os.makedirs(TEMP_DIR)
 

--- a/server/nlp/nlp.py
+++ b/server/nlp/nlp.py
@@ -96,8 +96,8 @@ class NLProcessor:
     # summarization
     @staticmethod
     def summarize(doc):
-        if not doc:
-            return []
+        if not doc: return ''
+
         sentences = sent_tokenize(doc)
         tokens = list(
             {
@@ -130,8 +130,8 @@ class NLProcessor:
             for sentence in sentences
         ]
         sentence_scores.sort(reverse=True, key=lambda x: x[1])
-        return [
+        return ''.join([
             (NLProcessor.normalize(sentence))
             for sentence, _ in sentence_scores[: max(2, int(len(sentences) / 20))]
-        ]
+        ])
 

--- a/server/nlp/nlp.py
+++ b/server/nlp/nlp.py
@@ -14,7 +14,7 @@ class NLProcessor:
     __word_vectors_id = 'word2vec-google-news-300'
     __word_vectors = None
     __sim_requirements = None
-    __sim_statements = list()
+    __sim_topic_summaries = dict()
     __sentimentIA = SentimentIntensityAnalyzer()
 
 

--- a/server/nlp/nlp.py
+++ b/server/nlp/nlp.py
@@ -30,6 +30,7 @@ class NLProcessor:
 
         return [NLProcessor.__ps.stem(token) for token in tokens] if stem else tokens
 
+    # normalize document
     @staticmethod
     def normalize(doc):
         return ' '.join(NLProcessor.__normal_tokens(doc))

--- a/server/nlp/nlp.py
+++ b/server/nlp/nlp.py
@@ -91,7 +91,10 @@ class NLProcessor:
     # compress multiple whitespace into one space
     @staticmethod
     def preprocess_article(doc):
-        return re.sub("\s+", " ", doc)
+        paragraph = re.sub("\s+", " ", doc)
+        if any(c in paragraph for c in "/\n_|\\@") or len(paragraph) < 10:
+            return None
+        return paragraph
 
     # summarization
     @staticmethod

--- a/server/nlp/nlp.py
+++ b/server/nlp/nlp.py
@@ -98,10 +98,9 @@ class NLProcessor:
     def summarize(doc):
         if not doc: return ''
 
-        sentences = [NLProcessor.__normal_tokens(sent) for sent in sent_tokenize(doc)]
+        sentences = [NLProcessor.__normal_tokens(sent, stem=False) for sent in sent_tokenize(doc)]
         tokens_flat = [token for sent in sentences for token in sent]
         token_freqs = [(token, tokens_flat.count(token)) for token in set(tokens_flat)]
-        print(token_freqs)
         max_freq = max(token_freqs, key=lambda tf: tf[1])[1]
 
         weighted_freqs = { tf[0]: tf[1] / max_freq for tf in token_freqs }

--- a/server/nlp/nlp.py
+++ b/server/nlp/nlp.py
@@ -68,7 +68,7 @@ class NLProcessor:
     def similarity(doc):
         if len(NLProcessor.__sim_topic_summaries) == 0: return 0
         if NLProcessor.__sim_requirements:
-            compare_normal_tokens = NLProcessor.__normal_tokens(doc)
+            compare_normal_tokens = set(NLProcessor.__normal_tokens(doc))
             if not (NLProcessor.__sim_requirements & compare_normal_tokens):
                 return 0
         topic_sims = {

--- a/server/nlp/nlp.py
+++ b/server/nlp/nlp.py
@@ -73,7 +73,7 @@ class NLProcessor:
                 return 0
         topic_sims = {
             topic: 1 / sum([
-                NLProcessor.__get_word_vectors().wmdistance(NLProcessor.__normal_tokens(doc), summary)
+                NLProcessor.__get_word_vectors().wmdistance(NLProcessor.__normal_tokens(doc, stem=False), summary)
             for summary in summaries]) * len(summaries)
         for topic, summaries in NLProcessor.__sim_topic_summaries.items()}
         return max(topic_sims.values())

--- a/server/run-backend
+++ b/server/run-backend
@@ -47,8 +47,7 @@ if __name__ == "__main__":
     ts = time_start("NLP setup ...")
     PageProcessor.setup_censoring(
         censoring_requirements,
-        DatabaseNegative.get_summaries(),
-        DatabaseNegative.get_topics(),
+        DatabaseNegative.get_summaries_by_topics()
     )
     time_finish(ts)
     print("setup done, waiting for connection\n")

--- a/server/scrape-negative
+++ b/server/scrape-negative
@@ -23,7 +23,7 @@ if __name__ == "__main__":
 
     def process_page(page_processor, url, query):
         if url in DatabaseNegative.get_sources(): return
-        summary = "".join(NLProcessor.summarize(page_processor.get_fulltext()))
+        summary = NLProcessor.summarize(page_processor.get_fulltext())
         DatabaseNegative.insert(query, summary, url)
     scrape_news_pages(NEGATIVE_QUERIES, args.narticles, process_page)
     print("DONE")

--- a/server/scrape-negative
+++ b/server/scrape-negative
@@ -22,8 +22,8 @@ if __name__ == "__main__":
     from database.mock_database import DatabaseNegative
 
     def process_page(page_processor, url, query):
-        summarization = "".join(NLProcessor.summarize(page_processor.get_fulltext()))
-        DatabaseNegative.insert((url, summarization, query))
+        summary = "".join(NLProcessor.summarize(page_processor.get_fulltext()))
+        DatabaseNegative.insert(query, summary, url)
     scrape_news_pages(NEGATIVE_QUERIES, args.narticles, process_page)
     print("DONE")
 

--- a/server/scrape-negative
+++ b/server/scrape-negative
@@ -6,7 +6,7 @@ validate_venv()
 import sys, argparse
 
 from definitions import NEGATIVE_QUERIES
-from scraper.scrape_news import scrape_news_urls
+from scraper.scrape_news import scrape_news_pages
 from nlp.nlp import NLProcessor
 
 if __name__ == "__main__":
@@ -24,6 +24,6 @@ if __name__ == "__main__":
     def process_page(page_processor, url, query):
         summarization = "".join(NLProcessor.summarize(page_processor.get_fulltext()))
         DatabaseNegative.insert((url, summarization, query))
-    scrape_news_urls(NEGATIVE_QUERIES, args.narticles, process_page)
+    scrape_news_pages(NEGATIVE_QUERIES, args.narticles, process_page)
     print("DONE")
 

--- a/server/scrape-negative
+++ b/server/scrape-negative
@@ -22,6 +22,7 @@ if __name__ == "__main__":
     from database.mock_database import DatabaseNegative
 
     def process_page(page_processor, url, query):
+        if url in DatabaseNegative.get_sources(): return
         summary = "".join(NLProcessor.summarize(page_processor.get_fulltext()))
         DatabaseNegative.insert(query, summary, url)
     scrape_news_pages(NEGATIVE_QUERIES, args.narticles, process_page)

--- a/server/scrape-positive
+++ b/server/scrape-positive
@@ -7,7 +7,7 @@ import sys, argparse
 
 from definitions import *
 from helpers.cleanup import clear_temp_files
-from scraper.scrape_news import scrape_news_urls
+from scraper.scrape_news import scrape_news_pages
 from database.mock_database import DatabasePositive
 from nlp.nlp import NLProcessor
 from btm.script.infer import infer_file, BTMInferrer
@@ -46,7 +46,7 @@ def scrape(narticles):
             if any(c in paragraph for c in ["  ", "/", "\n", "_", "|", "\\_"]):
                 continue
             DatabasePositive.insert_paragraph(paragraph)
-    scrape_news_urls(POSITIVE_QUERIES, narticles, process_page)
+    scrape_news_pages(POSITIVE_QUERIES, narticles, process_page)
     print("DONE")
 
 

--- a/server/scrape-positive
+++ b/server/scrape-positive
@@ -43,7 +43,7 @@ def scrape(narticles):
     def process_page(page_processor, url, query):
         paragraphs = page_processor.get_all_paragraphs()
         for paragraph in paragraphs:
-            if any(c in paragraph for c in ["  ", "/", "\n", "_", "|", "\\_"]):
+            if any(c in paragraph for c in "  /\n_|\\@"):
                 continue
             DatabasePositive.insert_paragraph(paragraph)
     scrape_news_pages(POSITIVE_QUERIES, narticles, process_page)

--- a/server/scrape-positive
+++ b/server/scrape-positive
@@ -43,9 +43,8 @@ def scrape(narticles):
     def process_page(page_processor, url, query):
         paragraphs = page_processor.get_all_paragraphs()
         for paragraph in paragraphs:
-            if any(c in paragraph for c in "  /\n_|\\@"):
-                continue
-            DatabasePositive.insert_paragraph(paragraph)
+            processed = NLProcessor.preprocess_article(paragraph)
+            if processed: DatabasePositive.insert_paragraph(processed)
     scrape_news_pages(POSITIVE_QUERIES, narticles, process_page)
     print("DONE")
 

--- a/server/scraper/article_scraper.py
+++ b/server/scraper/article_scraper.py
@@ -101,7 +101,7 @@ class GoogleScraper:
             results_prev = results
             results = fetch_results()
             time.sleep(3)
-        self.__log("results fetched")
+        self.__log("results fetched, extracting urls now")
 
         urls = list()
         for url in results:

--- a/server/scraper/scrape_news.py
+++ b/server/scraper/scrape_news.py
@@ -3,7 +3,7 @@ import requests
 from scraper.article_scraper import GoogleScraper
 from scraper.page_processor import PageProcessor
 
-def scrape_news_urls(queries, n_articles, pp_callback):
+def scrape_news_pages(queries, n_articles, pp_callback):
     scraper = GoogleScraper(verbose=True, log_prefix="    \033[1mscraper:\033[0m ")
     for i, query in enumerate(queries):
         print(f"\033[1mquery {i+1}/{len(queries)}\033[0m")


### PR DESCRIPTION
close #13 

### changes

- **change negative database structure** → you should delete any existing negative database file before testing
    - summaries are saved as lists by topics since this is the structure we need in NLProcessor
- rewrite most of NLProcessor
- change name `scrape_news_urls` to `scrape_news_pages` since the callback passes a live PageProcessor
- small adjustment in logging of scraper
- prevents negative scraping from using same url twice as requested in #4
- cleans up articles from `scrape-positive` before adding them to database 