### PR TITLE
Fix `activate` not working in bash

### DIFF
--- a/server/activate
+++ b/server/activate
@@ -1,5 +1,6 @@
 # source venv activate
-source `dirname $(realpath $0)`/.venv/bin/activate
+SOURCE_PATH=`test $ZSH_VERSION && echo ${(%):-%N} || echo $BASH_SOURCE`
+source `dirname $(realpath $SOURCE_PATH)`/.venv/bin/activate
 # rename original deactivate function
 eval "$(declare -f deactivate | sed 's/deactivate/original_deactivate/g')"
 # define env variables


### PR DESCRIPTION
Reason: `$0` is set to shell path and not path of script if sourced in bash

- bash provides alternative `BASH_SOURCE`
- in zsh, it is safer to use `${(%):-%N}` than `$0` (see [this](https://stackoverflow.com/questions/9901210/bash-source0-equivalent-in-zsh))

made to set path based on shell accordingly, now works with zsh and bash